### PR TITLE
Pass a shell class instead of a string to `xonsh.main.setup`.

### DIFF
--- a/xonsh_jupyter/kernel.py
+++ b/xonsh_jupyter/kernel.py
@@ -20,6 +20,8 @@ from xonsh.main import setup
 from zmq.error import ZMQError
 from zmq.eventloop import ioloop, zmqstream
 
+from xonsh_jupyter.shell import JupyterShell
+
 MAX_SIZE = 8388608  # 8 Mb
 DELIM = b"<IDS|MSG>"
 
@@ -484,7 +486,7 @@ class XonshKernel:
 
 def main():
     setup(
-        shell_type="jupyter",
+        shell_type=JupyterShell,
         env={"PAGER": "cat"},
         aliases={"less": "cat"},
         xontribs=["coreutils"],


### PR DESCRIPTION
Fixes #6

The jupyter kernel was failing to start as `xonsh.shell.Shell` no longer accepted "jupyter" as a known shell name, and instead required a shell class to be passed.

