### PR TITLE
Always capture subprocess stdout

### DIFF
--- a/xonsh_jupyter/kernel.py
+++ b/xonsh_jupyter/kernel.py
@@ -491,7 +491,10 @@ class XonshKernel:
 def main():
     setup(
         shell_type=JupyterShell,
-        env={"PAGER": "cat"},
+        env={
+            "PAGER": "cat",
+            "XONSH_CAPTURE_ALWAYS": True,
+        },
         aliases={"less": "cat"},
         xontribs=["coreutils"],
         threadable_predictors={"git": predict_true, "man": predict_true},


### PR DESCRIPTION
This PR sets the standard output of subprocess to be captured by default in the xonsh kernel.

This means that the output of external commands will sent to connected kernel clients, instead of being displayed in the terminal where the kernel is running.