### PR TITLE
Fix pre-commit issues

### DIFF
--- a/tests/test_xonfig.py
+++ b/tests/test_xonfig.py
@@ -39,9 +39,8 @@ def fake_lib(monkeypatch):
     modules_to_delete = []
 
     for m, mod in sys.modules.items():
-        if m.startswith(fake_packages):
-            if mod.__file__.startswith(fake_lib_path):
-                modules_to_delete.append(m)  # can't modify collection while iterating
+        if m.startswith(fake_packages) and mod.__file__.startswith(fake_lib_path):
+            modules_to_delete.append(m)  # can't modify collection while iterating
 
     for m in modules_to_delete:
         del sys.modules[m]

--- a/tests/test_xonfig.py
+++ b/tests/test_xonfig.py
@@ -87,7 +87,8 @@ def test_xonfig_kernel_with_jupyter(monkeypatch, capsys, fake_lib, xession):
         nonlocal cap_spec
         cap_args = dict(args=args, kw=kwargs)
         spec_file = os.path.join(args[1], "kernel.json")
-        cap_spec = json.load(open(spec_file))
+        with open(spec_file) as f:
+            cap_spec = json.load(f)
 
     def mock_get_kernel_spec(*args, **kwargs):
         raise jupyter_client.kernelspec.NoSuchKernel("xonsh")

--- a/tests/test_xonfig.py
+++ b/tests/test_xonfig.py
@@ -33,7 +33,8 @@ def fake_lib(monkeypatch):
     monkeypatch.syspath_prepend(fake_lib_path)
     yield
 
-    # monkeypatch will have restored sys.path, but it's up to us to purge the imported modules
+    # monkeypatch will have restored sys.path, 
+    # but it's up to us to purge the imported modules
     fake_packages = tuple(f.name for f in os.scandir(fake_lib_path) if os.path.isdir(f))
     modules_to_delete = []
 

--- a/tests/test_xonfig.py
+++ b/tests/test_xonfig.py
@@ -33,7 +33,7 @@ def fake_lib(monkeypatch):
     monkeypatch.syspath_prepend(fake_lib_path)
     yield
 
-    # monkeypatch will have restored sys.path, 
+    # monkeypatch will have restored sys.path,
     # but it's up to us to purge the imported modules
     fake_packages = tuple(f.name for f in os.scandir(fake_lib_path) if os.path.isdir(f))
     modules_to_delete = []

--- a/xonsh_jupyter/alias.py
+++ b/xonsh_jupyter/alias.py
@@ -55,7 +55,8 @@ def jupyter_kernel(
         old_jup_kernel = ksm.get_kernel_spec(XONSH_JUPYTER_KERNEL)
         if not old_jup_kernel.resource_dir.startswith(prefix):
             print(
-                f"Removing existing Jupyter kernel found at {old_jup_kernel.resource_dir}"
+                f"Removing existing Jupyter kernel found" 
+                + f"at {old_jup_kernel.resource_dir}"
             )
         ksm.remove_kernel_spec(XONSH_JUPYTER_KERNEL)
     except NoSuchKernel:

--- a/xonsh_jupyter/alias.py
+++ b/xonsh_jupyter/alias.py
@@ -55,7 +55,7 @@ def jupyter_kernel(
         old_jup_kernel = ksm.get_kernel_spec(XONSH_JUPYTER_KERNEL)
         if not old_jup_kernel.resource_dir.startswith(prefix):
             print(
-                f"Removing existing Jupyter kernel found" 
+                "Removing existing Jupyter kernel found"
                 + f"at {old_jup_kernel.resource_dir}"
             )
         ksm.remove_kernel_spec(XONSH_JUPYTER_KERNEL)

--- a/xonsh_jupyter/kernel.py
+++ b/xonsh_jupyter/kernel.py
@@ -196,7 +196,7 @@ class XonshKernel:
     def dprint(self, level, *args, **kwargs):
         """Print but with debug information."""
         if level <= self.debug_level:
-            print("DEBUG" + str(level) + ":", file=sys.__stdout__, *args, **kwargs)
+            print("DEBUG" + str(level) + ":", *args, file=sys.__stdout__, **kwargs)
             sys.__stdout__.flush()
 
     def sign(self, messages):

--- a/xonsh_jupyter/kernel.py
+++ b/xonsh_jupyter/kernel.py
@@ -237,7 +237,7 @@ class XonshKernel:
 
         messages = list(map(dump_bytes, [header, parent_header, metadata, content]))
         signature = self.sign(messages)
-        parts = [DELIM, signature] + messages
+        parts = [DELIM, signature, *messages]
         if identities:
             parts = identities + parts
         self.dprint(3, "send parts:", parts)

--- a/xonsh_jupyter/kernel.py
+++ b/xonsh_jupyter/kernel.py
@@ -11,6 +11,7 @@ import uuid
 from argparse import ArgumentParser
 from collections.abc import Set
 from pprint import pformat
+from typing import ClassVar
 
 import zmq
 from xonsh import __version__ as version
@@ -54,7 +55,7 @@ class XonshKernel:
     language = "xonsh"
     language_version = version.split(".")[:3]
     banner = "Xonsh - Python-powered, cross-platform shell"
-    language_info = {
+    language_info: ClassVar = {
         "name": "xonsh",
         "version": version,
         "pygments_lexer": "xonsh",
@@ -62,7 +63,7 @@ class XonshKernel:
         "mimetype": "text/x-sh",
         "file_extension": ".xsh",
     }
-    signature_schemes = {"hmac-sha256": hashlib.sha256}
+    signature_schemes: ClassVar = {"hmac-sha256": hashlib.sha256}
 
     def __init__(self, debug_level=0, session_id=None, config=None, **kwargs):
         """

--- a/xonsh_jupyter/shell.py
+++ b/xonsh_jupyter/shell.py
@@ -145,4 +145,4 @@ class JupyterShell(BaseShell):
         return rtn
 
 
-__all__ = (JupyterShell,)
+__all__ = (JupyterShell,)  # type: ignore[misc]


### PR DESCRIPTION
Fix https://results.pre-commit.ci/run/github/471969357/1742286000.YziDOMD9RTW4I9DGyyzKeA

<details>

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'select' -> 'lint.select'
tests/test_xonfig.py:36:89: E501 Line too long (94 > 88)
   |
34 |     yield
35 | 
36 |     # monkeypatch will have restored sys.path, but it's up to us to purge the imported modules
   |                                                                                         ^^^^^^ E501
37 |     fake_packages = tuple(f.name for f in os.scandir(fake_lib_path) if os.path.isdir(f))
38 |     modules_to_delete = []
   |

tests/test_xonfig.py:41:9: SIM102 Use a single `if` statement instead of nested `if` statements
   |
40 |       for m, mod in sys.modules.items():
41 |           if m.startswith(fake_packages):
   |  _________^
42 | |             if mod.__file__.startswith(fake_lib_path):
   | |______________________________________________________^ SIM102
43 |                   modules_to_delete.append(m)  # can't modify collection while iterating
   |
   = help: Combine `if` statements using `and`

tests/test_xonfig.py:90:30: SIM115 Use context handler for opening files
   |
88 |         cap_args = dict(args=args, kw=kwargs)
89 |         spec_file = os.path.join(args[1], "kernel.json")
90 |         cap_spec = json.load(open(spec_file))
   |                              ^^^^ SIM115
91 | 
92 |     def mock_get_kernel_spec(*args, **kwargs):
   |

xonsh_jupyter/alias.py:58:89: E501 Line too long (90 > 88)
   |
56 |         if not old_jup_kernel.resource_dir.startswith(prefix):
57 |             print(
58 |                 f"Removing existing Jupyter kernel found at {old_jup_kernel.resource_dir}"
   |                                                                                         ^^ E501
59 |             )
60 |         ksm.remove_kernel_spec(XONSH_JUPYTER_KERNEL)
   |

xonsh_jupyter/kernel.py:57:21: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
   |
55 |       language_version = version.split(".")[:3]
56 |       banner = "Xonsh - Python-powered, cross-platform shell"
57 |       language_info = {
   |  _____________________^
58 | |         "name": "xonsh",
59 | |         "version": version,
60 | |         "pygments_lexer": "xonsh",
61 | |         "codemirror_mode": "shell",
62 | |         "mimetype": "text/x-sh",
63 | |         "file_extension": ".xsh",
64 | |     }
   | |_____^ RUF012
65 |       signature_schemes = {"hmac-sha256": hashlib.sha256}
   |

xonsh_jupyter/kernel.py:65:25: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
   |
63 |         "file_extension": ".xsh",
64 |     }
65 |     signature_schemes = {"hmac-sha256": hashlib.sha256}
   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF012
66 | 
67 |     def __init__(self, debug_level=0, session_id=None, config=None, **kwargs):
   |

xonsh_jupyter/kernel.py:199:68: B026 Star-arg unpacking after a keyword argument is strongly discouraged
    |
197 |         """Print but with debug information."""
198 |         if level <= self.debug_level:
199 |             print("DEBUG" + str(level) + ":", file=sys.__stdout__, *args, **kwargs)
    |                                                                    ^^^^^ B026
200 |             sys.__stdout__.flush()
    |

xonsh_jupyter/kernel.py:240:17: RUF005 Consider `[DELIM, signature, *messages]` instead of concatenation
    |
238 |         messages = list(map(dump_bytes, [header, parent_header, metadata, content]))
239 |         signature = self.sign(messages)
240 |         parts = [DELIM, signature] + messages
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF005
241 |         if identities:
242 |             parts = identities + parts
    |
    = help: Replace with `[DELIM, signature, *messages]`

Found 8 errors.
No fixes available (1 hidden fix can be enabled with the `--unsafe-fixes` option).

ruff-format..............................................................Passed
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

xonsh_jupyter/shell.py:153: error: Type of __all__ must be "Sequence[str]", not "tuple[type[JupyterShell]]"  [misc]
Found 1 error in 1 file (checked 6 source files)
```

</details>

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
